### PR TITLE
Enable historical RPC as global env

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -34,5 +34,11 @@
   "license": "GPL-3.0",
   "requirements": {
     "minimumDappnodeVersion": "0.2.50"
-  }
+  },
+  "globalEnvs": [
+    {
+      "envs": ["OP_ENABLE_HISTORICAL_RPC"],
+      "services": ["geth"]
+    }
+  ]
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,6 @@ services:
       - P2P_PORT=30505
       - "HISTORICAL_RPC_URL=http://op-l2geth.dappnode:8545"
       - "SEQUENCER_HTTP_URL=https://mainnet-sequencer.optimism.io"
-      - ENABLE_HISTORICAL_RPC=true
     image: "erigon.op-erigon.dnp.dappnode.eth:0.1.0"
 volumes:
   data: {}

--- a/op-erigon/entrypoint.sh
+++ b/op-erigon/entrypoint.sh
@@ -7,7 +7,7 @@ DATA_DIR=/data
 # Tx pool gossip is disabled as it is not supported yet
 # Max peers set to 0 to disable peer discovery (will be enabled in the future for snap sync)
 
-if [ "$ENABLE_HISTORICAL_RPC" = "true" ]; then
+if [ "$_DAPPNODE_GLOBAL_OP_ENABLE_HISTORICAL_RPC" = "true" ]; then
   echo "[INFO - entrypoint] Enabling historical RPC"
   EXTRA_FLAGS="--rollup.historicalrpc $HISTORICAL_RPC_URL"
 fi


### PR DESCRIPTION
Historical RPC (boolean) is set via global env