### PR TITLE
fix: resolved storage & config issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build_*
 releases.json
+.DS_Store

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,16 +4,16 @@ services:
     build:
       context: op-erigon
       args:
-        UPSTREAM_VERSION: v2.51.0-0.3.1
+        UPSTREAM_VERSION: 2.51.0-0.3.1
     volumes:
-      - "data:/data"
+      - "data:/home/op-erigon/.local/share"
     restart: unless-stopped
     environment:
-      - "EXTRA_FLAGS=--http.api=engine,eth,erigon,web3,net,debug,trace,txpool"
-      - P2P_PORT=30505
-      - "HISTORICAL_RPC_URL=http://op-l2geth.dappnode:8545"
-      - "SEQUENCER_HTTP_URL=https://mainnet-sequencer.optimism.io"
-    image: "erigon.op-erigon.dnp.dappnode.eth:0.1.0"
+      EXTRA_OPTs: "--http.api=engine,eth,erigon,web3,net,debug,trace,txpool"
+      P2P_PORT: 30505
+      HISTORICAL_RPC_URL: "http://op-l2geth.dappnode:8545"
+      SEQUENCER_HTTP_URL: "https://mainnet-sequencer.optimism.io"
+    image: "erigon.op-erigon.dnp.dappnode.eth:0.1.1"
     ports:
       - "30505:30505/tcp"
       - "30505:30505/udp"


### PR DESCRIPTION
- fixed issue where the data would not be stored in a volume 
- fixed issue where if _DAPPNODE_GLOBAL_OP_ENABLE_HISTORICAL_RPC was true, the EXRA_OPTs field would be replace instead of being amended, making any user inputed EXTRA_OPTs non-functional
- added  --maxpeers=0  to the entrypoint as per testinprod's recommandation, given that it isn't supported by optimism
