### PR TITLE
chore: bump upstream verison

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "op-erigon.dnp.dappnode.eth",
   "version": "0.1.1",
-  "upstreamVersion": "2.51.0-0.3.1",
+  "upstreamVersion": "2.53.4-0.3.1",
   "upstreamRepo": "testinprod-io/op-erigon",
   "upstreamArg": "UPSTREAM_VERSION",
   "shortDescription": "Erigon execution client for Optimism",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: op-erigon
       args:
-        UPSTREAM_VERSION: 2.51.0-0.3.1
+        UPSTREAM_VERSION: 2.53.4-0.3.1
     volumes:
       - "data:/home/op-erigon/.local/share"
     restart: unless-stopped


### PR DESCRIPTION
Change:

- Bumped the version to the new upstream version, which the GH action fails to do because of naming inconsistencies in the upstream deployments. 

Note:
- did not bump the local version number from 0.1.1 to 0.1.2 as 0.1.1 was not published to the APM repository.

Tests:
- tested as an update from 0.1.0 successfully
- tested as a new install successfully
