### PR TITLE
fix exposeable service, add mainservice, rename exposable to include …

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -7,6 +7,7 @@
   "shortDescription": "Erigon execution client for Optimism",
   "description": "Minimal fork of Erigon, responsible for executing the blocks it receives from the rollup node and storing state. It also exposes standard JSON-RPC methods to query blockchain data and submit transactions to the network.",
   "type": "service",
+  "mainService": "erigon",
   "chain": "ethereum",
   "author": "DAppNode Association <admin@dappnode.io> (https://github.com/dappnode)",
   "categories": ["Blockchain"],
@@ -15,13 +16,13 @@
   "links": {
     "homepage": "https://github.com/dappnode/DAppNodePackage-op-erigon#readme",
     "api": "http://op-erigon.dappnode:8545",
-    "engineAPI": "http://op-erigon.dappnode:8551"
+    "engineAPI": "ws://op-erigon.dappnode:8551"
   },
   "exposable": [
     {
       "name": "OP Erigon JSON-RPC (HTTP+WS)",
-      "description": "HTTP+WS JSON-RPC endpoint for OP",
-      "serviceName": "op-erigon",
+      "description": "HTTP+WS JSON-RPC endpoint for OP-Erigon",
+      "serviceName": "erigon",
       "port": 8545
     }
   ],


### PR DESCRIPTION
…Erigon not just OP fixed listing of engineAPI to `ws://` not `http://` as the engine must connect via WS, not HTTP,

HTTP only works on localhost, these are fine for natively running or using the same container, but seprate containers cannot make it work on anything but localhost, this is how all OP and OP based chains docs describe how to use mulriple containers/services and they all use WS as the engine, its been working for months for me with OP-Geth and OP-Node (both with my PRs, not im catching up with OP erigon, and then l2geth, which needs to download a snapshot first to use as the predefined datadir, snapshots are online, i will work on finishing that, personally i havent needed it since i have a fully synced legacy Optimism client pre-bedrock to point to, but gotta change that, its just running a full OP node with historical its like 5-6TB minimum AFAIK,  archival is even higher, but should make it work still for those who desire