### PR TITLE
Fix flags

### DIFF
--- a/op-erigon/entrypoint.sh
+++ b/op-erigon/entrypoint.sh
@@ -50,7 +50,7 @@ fi
 echo "[INFO - entrypoint] Starting Erigon"
 exec erigon --datadir=${DATADIR}/database \
   --rollup.sequencerhttp=${SEQUENCER_HTTP_URL} \
-  --rollup.disabletxpoolgossip=true \
+  --txpool.gossip.disable=true \
   --maxpeers=0 \
   --nodiscover \
   --http.addr=0.0.0.0 \
@@ -68,4 +68,5 @@ exec erigon --datadir=${DATADIR}/database \
   --authrpc.vhosts='*' \
   --authrpc.port=8551 \
   --chain=op-mainnet \
+  --db.size.limit=8TB \
   ${EXTRA_OPTs}


### PR DESCRIPTION
Same as https://github.com/dappnode/DAppNodePackage-goerli-erigon/pull/85

Also fixed this warning: 
```
[WARN] [04-09|23:25:59.089] --rollup.disabletxpoolgossip flag is deprecated. use --txpool.gossip.disable 
```